### PR TITLE
Fix/nex 89 from eloquent to oat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Composer NPM bridge changelog
 
+##  0.1.1
+
+- Change the package name from `eloquent` to `oat-sa`
+
 ##  0.1.0
 
 - Added npm argument config parameter.

--- a/README.md
+++ b/README.md
@@ -2,23 +2,14 @@
 
 *NPM integration for Composer packages.*
 
-[![Current version image][version-image]][current version]
-[![Current build status image][build-image]][current build status]
-[![Current coverage status image][coverage-image]][current coverage status]
-
-[build-image]: http://img.shields.io/travis/eloquent/composer-npm-bridge/develop.svg?style=flat-square "Current build status for the develop branch"
-[coverage-image]: https://img.shields.io/codecov/c/github/eloquent/composer-npm-bridge/develop.svg?style=flat-square "Current test coverage for the develop branch"
-[current build status]: https://travis-ci.org/eloquent/composer-npm-bridge
-[current coverage status]: https://codecov.io/github/eloquent/composer-npm-bridge
-[current version]: https://packagist.org/packages/eloquent/composer-npm-bridge
-[version-image]: https://img.shields.io/packagist/v/eloquent/composer-npm-bridge.svg?style=flat-square "This project uses semantic versioning"
+> This package is a fork from https://github.com/eloquent/composer-npm-bridge (thanks to them!)
 
 ## Installation
 
-- Available as [Composer] package [eloquent/composer-npm-bridge].
+- Available as [Composer] package [oat-sa/composer-npm-bridge].
 
 [composer]: http://getcomposer.org/
-[eloquent/composer-npm-bridge]: https://packagist.org/packages/eloquent/composer-npm-bridge
+[oat-sa/composer-npm-bridge]: https://packagist.org/packages/oat-sa/composer-npm-bridge
 
 ## Requirements
 
@@ -26,10 +17,10 @@
 
 ## Usage
 
-To utilize the *Composer NPM bridge*, simply add `eloquent/composer-npm-bridge`
+To utilize the *Composer NPM bridge*, simply add `oat-sa/composer-npm-bridge`
 to the `require` section of the project's Composer configuration:
 
-    composer require eloquent/composer-npm-bridge
+    composer require oat-sa/composer-npm-bridge
 
 NPM dependencies are specified via a [package.json] configuration file in the
 root directory of the Composer package. Source control should be configured to
@@ -43,7 +34,7 @@ The *Composer NPM bridge* is a Composer plugin that automatically installs and
 updates [NPM] packages whenever the corresponding Composer command is executed.
 To detect compatible packages, the bridge inspects Composer package
 configuration information to find packages that directly require the
-`eloquent/composer-npm-bridge` Composer package itself.
+`oat-sa/composer-npm-bridge` Composer package itself.
 
 In addition to normal operation, `composer install` will [install] NPM
 dependencies for all Composer packages using the bridge. This includes the root

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,27 @@
 {
     "name": "oat-sa/composer-npm-bridge",
+    "version": "0.1.1",
     "description": "NPM integration for Composer packages.",
     "keywords": ["composer", "npm", "package", "integration", "bridge", "plugin", "composer-plugin"],
-    "homepage": "https://github.com/eloquent/composer-npm-bridge",
+    "homepage": "https://github.com/oat-sa/composer-npm-bridge",
     "license": "MIT",
-    "authors": [
-        {
-            "name": "Erin Millard",
-            "email": "ezzatron@gmail.com",
-            "homepage": "http://ezzatron.com/"
-        }
-    ],
+    "authors": [{
+        "name": "Erin Millard",
+        "email": "ezzatron@gmail.com",
+        "homepage": "http://ezzatron.com/",
+        "role": "original author"
+    }, {
+        "name": "OAT SA",
+        "email": "contact@taotesting.com",
+        "homepage": "https://taotestingg.com",
+        "role": "forkers"
+    }],
     "type": "composer-plugin",
     "require": {
-        "php": ">=7",
         "composer-plugin-api": "^1"
     },
     "require-dev": {
+        "php": ">=7",
         "composer/composer": "dev-master",
         "eloquent/phony-phpunit": "^3",
         "errors/exceptions": "^0.2",
@@ -36,3 +41,4 @@
         }
     }
 }
+

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c70e79f5360ac9b55979ad4006711e6b",
+    "content-hash": "cf7f726761ac779c5f5ff98ffeb421c7",
     "packages": [],
     "packages-dev": [
         {
@@ -2543,11 +2543,10 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {
-        "php": ">=7",
-        "composer-plugin-api": "^1"
+    "platform": [],
+    "platform-dev": {
+        "php": ">=7"
     },
-    "platform-dev": [],
     "platform-overrides": {
         "php": "7.0.99999"
     }

--- a/src/NpmBridge.php
+++ b/src/NpmBridge.php
@@ -84,14 +84,14 @@ class NpmBridge
         bool $includeDevDependencies = false
     ): bool {
         foreach ($package->getRequires() as $link) {
-            if ('eloquent/composer-npm-bridge' === $link->getTarget()) {
+            if ('oat-sa/composer-npm-bridge' === $link->getTarget()) {
                 return true;
             }
         }
 
         if ($includeDevDependencies) {
             foreach ($package->getDevRequires() as $link) {
-                if ('eloquent/composer-npm-bridge' === $link->getTarget()) {
+                if ('oat-sa/composer-npm-bridge' === $link->getTarget()) {
                     return true;
                 }
             }


### PR DESCRIPTION
Change the package name from `eloquent` to `oat-sa` in the different location so the metadata are up date, but also if we publish it into packagist, the transititive dependencies are discovered using the package name.