### PR TITLE
Feature/move to php56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Composer NPM bridge changelog
 
+##  0.3.0
+
+- Downgrade to php5.6
+
 ##  0.1.1
 
 - Run `npm install` on `composer update`

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "composer/composer": "dev-master",
         "eloquent/phony-phpunit": "^1",
         "errors/exceptions": "^0.2",
-        "phpunit/phpunit": "^6"
+        "phpunit/phpunit": "^5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "oat-sa/composer-npm-bridge",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "NPM integration for Composer packages.",
     "keywords": ["composer", "npm", "package", "integration", "bridge", "plugin", "composer-plugin"],
     "homepage": "https://github.com/oat-sa/composer-npm-bridge",
@@ -21,7 +21,6 @@
         "composer-plugin-api": "^1"
     },
     "require-dev": {
-        "php": ">=7",
         "composer/composer": "dev-master",
         "eloquent/phony-phpunit": "^3",
         "errors/exceptions": "^0.2",
@@ -34,11 +33,6 @@
     },
     "extra": {
         "class": "Eloquent\\Composer\\NpmBridge\\NpmBridgePlugin"
-    },
-    "config": {
-        "platform": {
-            "php": "7.0.99999"
-        }
     }
 }
 

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,11 @@
     }],
     "type": "composer-plugin",
     "require": {
+        "php" : ">=5.6",
         "composer-plugin-api": "^1"
     },
     "require-dev": {
+        "php" : ">=7",
         "composer/composer": "dev-master",
         "eloquent/phony-phpunit": "^3",
         "errors/exceptions": "^0.2",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     }],
     "type": "composer-plugin",
     "require": {
+        "php": ">=5.6",
         "composer-plugin-api": "^1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,15 @@
     }],
     "type": "composer-plugin",
     "require": {
+        "php" : ">=5.6",
         "composer-plugin-api": "^1"
     },
     "require-dev": {
+        "php" : ">=7",
         "composer/composer": "dev-master",
-        "eloquent/phony-phpunit": "^1",
+        "eloquent/phony-phpunit": "^3",
         "errors/exceptions": "^0.2",
-        "phpunit/phpunit": "^5"
+        "phpunit/phpunit": "^6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,11 @@
     }],
     "type": "composer-plugin",
     "require": {
-        "php" : ">=5.6",
         "composer-plugin-api": "^1"
     },
     "require-dev": {
-        "php" : ">=7",
         "composer/composer": "dev-master",
-        "eloquent/phony-phpunit": "^3",
+        "eloquent/phony-phpunit": "^1",
         "errors/exceptions": "^0.2",
         "phpunit/phpunit": "^6"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,13 @@
     }],
     "type": "composer-plugin",
     "require": {
-        "php" : ">=5.6",
         "composer-plugin-api": "^1"
     },
     "require-dev": {
-        "php" : ">=7",
         "composer/composer": "dev-master",
-        "eloquent/phony-phpunit": "^3",
+        "eloquent/phony-phpunit": "^1",
         "errors/exceptions": "^0.2",
-        "phpunit/phpunit": "^6"
+        "phpunit/phpunit": "^5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exception/NpmCommandFailedException.php
+++ b/src/Exception/NpmCommandFailedException.php
@@ -15,7 +15,7 @@ final class NpmCommandFailedException extends Exception
      * @param string         $command The executed command.
      * @param Exception|null $cause   The cause, if available.
      */
-    public function __construct(string $command, Exception $cause = null)
+    public function __construct($command, Exception $cause = null)
     {
         $this->command = $command;
 
@@ -31,7 +31,7 @@ final class NpmCommandFailedException extends Exception
      *
      * @return string The command.
      */
-    public function command(): string
+    public function command()
     {
         return $this->command;
     }

--- a/src/NpmBridge.php
+++ b/src/NpmBridge.php
@@ -108,7 +108,7 @@ class NpmBridge
 
         $packages = $this->vendorFinder->find($composer, $this);
 
-        if (count($packages) > 0) {
+        if (is_array($packages) && count($packages) > 0) {
             $isNpmAvailable = $this->client->isAvailable();
             $installationManager = $composer->getInstallationManager();
 
@@ -146,7 +146,8 @@ class NpmBridge
         }
     }
 
-    private function packageTimeout(array $extra) {
+    private function packageTimeout(array $extra)
+    {
         if (isset($extra[self::EXTRA_KEY][self::EXTRA_KEY_TIMEOUT])) {
             return intval($extra[self::EXTRA_KEY][self::EXTRA_KEY_TIMEOUT]);
         }
@@ -159,8 +160,12 @@ class NpmBridge
         return !empty($extra[self::EXTRA_KEY][self::EXTRA_KEY_OPTIONAL]);
     }
 
-    private function getNpmArguments(array $extra) {
-        return $extra[self::EXTRA_KEY][self::EXTRA_KEY_NPM_ARGUMENTS] ?? [];
+    private function getNpmArguments(array $extra)
+    {
+        if (isset($extra[self::EXTRA_KEY][self::EXTRA_KEY_NPM_ARGUMENTS])) {
+            return $extra[self::EXTRA_KEY][self::EXTRA_KEY_NPM_ARGUMENTS];
+        }
+        return [];
     }
 
     private $io;

--- a/src/NpmBridge.php
+++ b/src/NpmBridge.php
@@ -46,7 +46,7 @@ class NpmBridge
      * @throws NpmNotFoundException      If the npm executable cannot be located.
      * @throws NpmCommandFailedException If the operation fails.
      */
-    public function install(Composer $composer, bool $isDevMode = true)
+    public function install(Composer $composer, $isDevMode = true)
     {
         $this->io->write(
             '<info>Installing NPM dependencies for root project</info>'
@@ -81,7 +81,7 @@ class NpmBridge
      */
     public function isDependantPackage(
         PackageInterface $package,
-        bool $includeDevDependencies = false
+        $includeDevDependencies = false
     ) {
         foreach ($package->getRequires() as $link) {
             if ('oat-sa/composer-npm-bridge' === $link->getTarget()) {

--- a/src/NpmBridge.php
+++ b/src/NpmBridge.php
@@ -82,7 +82,7 @@ class NpmBridge
     public function isDependantPackage(
         PackageInterface $package,
         bool $includeDevDependencies = false
-    ): bool {
+    ) {
         foreach ($package->getRequires() as $link) {
             if ('oat-sa/composer-npm-bridge' === $link->getTarget()) {
                 return true;

--- a/src/NpmBridgeFactory.php
+++ b/src/NpmBridgeFactory.php
@@ -14,7 +14,7 @@ class NpmBridgeFactory
      *
      * @return self The newly created factory.
      */
-    public static function create(): self
+    public static function create()
     {
         return new self(
             new NpmVendorFinder(),
@@ -43,7 +43,7 @@ class NpmBridgeFactory
      *
      * @param IOInterface $io The i/o interface to use.
      */
-    public function createBridge(IOInterface $io): NpmBridge
+    public function createBridge(IOInterface $io)
     {
         return new NpmBridge($io, $this->vendorFinder, $this->client);
     }

--- a/src/NpmBridgePlugin.php
+++ b/src/NpmBridgePlugin.php
@@ -50,7 +50,7 @@ class NpmBridgePlugin implements PluginInterface, EventSubscriberInterface
      *
      * @return array<string,string> The events to listen to, and their associated handlers.
      */
-    public static function getSubscribedEvents(): array
+    public static function getSubscribedEvents()
     {
         // Issue #18 - disable if ENV set
         if (!empty(getenv('COMPOSER_NPM_BRIDGE_DISABLE'))) {

--- a/src/NpmClient.php
+++ b/src/NpmClient.php
@@ -62,7 +62,7 @@ class NpmClient
      * @throws NpmNotFoundException      If the npm executable cannot be located.
      * @throws NpmCommandFailedException If the operation fails.
      */
-    public function install(string $path = null, bool $isDevMode = true, int $timeout = null, $npmArguments = [])
+    public function install(string $path = null, $isDevMode = true, $timeout = null, $npmArguments = [])
     {
         if ($isDevMode) {
             $arguments = ['install'];

--- a/src/NpmClient.php
+++ b/src/NpmClient.php
@@ -19,7 +19,7 @@ class NpmClient
      *
      * @return self The newly created client.
      */
-    public static function create(): self
+    public static function create()
     {
         return new self(new ProcessExecutor(), new ExecutableFinder());
     }

--- a/src/NpmClient.php
+++ b/src/NpmClient.php
@@ -40,7 +40,7 @@ class NpmClient
         ExecutableFinder $executableFinder,
         $getcwd = 'getcwd',
         $chdir = 'chdir',
-        string $processExecutorClass = ProcessExecutor::class
+        $processExecutorClass = ProcessExecutor::class
     ) {
         $this->processExecutor = $processExecutor;
         $this->executableFinder = $executableFinder;

--- a/src/NpmClient.php
+++ b/src/NpmClient.php
@@ -62,7 +62,7 @@ class NpmClient
      * @throws NpmNotFoundException      If the npm executable cannot be located.
      * @throws NpmCommandFailedException If the operation fails.
      */
-    public function install(string $path = null, $isDevMode = true, $timeout = null, $npmArguments = [])
+    public function install($path = null, $isDevMode = true, $timeout = null, $npmArguments = [])
     {
         if ($isDevMode) {
             $arguments = ['install'];

--- a/src/NpmVendorFinder.php
+++ b/src/NpmVendorFinder.php
@@ -18,7 +18,7 @@ class NpmVendorFinder
      *
      * @return array<integer,PackageInterface> The list of NPM bridge enabled vendor packages.
      */
-    public function find(Composer $composer, NpmBridge $bridge): array
+    public function find(Composer $composer, NpmBridge $bridge)
     {
         $packages = $composer->getRepositoryManager()->getLocalRepository()
             ->getPackages();

--- a/test/suite/NpmBridgeTest.php
+++ b/test/suite/NpmBridgeTest.php
@@ -133,7 +133,7 @@ class NpmBridgeTest extends TestCase
         $this->client->install->throws($this->expected);
         $this->rootPackage->setRequires([$this->linkRoot3]);
 
-        $this->expectExceptionObject($this->expected);
+        $this->expectException(get_class($this->expected));
         $this->bridge->install($this->composer, false);
     }
 
@@ -179,7 +179,7 @@ class NpmBridgeTest extends TestCase
         $this->client->install->throws($this->expected);
         $this->vendorFinder->find->with($this->composer, $this->bridge)->returns([$this->packageA, $this->packageB]);
 
-        $this->expectExceptionObject($this->expected);
+        $this->expectException(get_class($this->expected));
         $this->bridge->install($this->composer, false);
     }
 


### PR DESCRIPTION
Ensure the composer-npm-bridge runs on _old & unsupported_ versions of php (5.6)  by downgrading the source code :/ 
 - remove the return type 
 - remove the type hint with default value that aren't null
 - remove the `??` operators

The tests run on PHP>7.0 but please ensure they're still running.
Installing this kind of composer : 
```
    "require": {
        "doctrine/inflector": "~1.0.0",
        "oat-sa/extension-pcisample": "dev-develop",
        "oat-sa/extension-tao-backoffice": "dev-develop",
        "oat-sa/extension-tao-community": "dev-develop",
        "oat-sa/extension-tao-delivery": "dev-develop",
        "oat-sa/extension-tao-devtools": "dev-develop",
        "oat-sa/extension-tao-funcacl": "dev-develop",
        "oat-sa/extension-tao-group": "dev-develop",
        "oat-sa/extension-tao-item": "dev-develop",
        "oat-sa/extension-tao-itemqti": "dev-develop",
        "oat-sa/extension-tao-itemqti-pci": "dev-develop",
        "oat-sa/extension-tao-itemqti-pic": "dev-develop",
        "oat-sa/extension-tao-outcome": "dev-develop",
        "oat-sa/extension-tao-outcomelti": "dev-develop",
        "oat-sa/extension-tao-outcomerds": "dev-develop",
        "oat-sa/extension-tao-outcomeui": "dev-develop",
        "oat-sa/extension-tao-task-queue": "dev-develop",
        "oat-sa/extension-tao-test": "dev-develop",
        "oat-sa/extension-tao-testqti": "dev-develop",
        "oat-sa/extension-tao-testqti-previewer": "dev-develop",
        "oat-sa/extension-tao-testtaker": "dev-develop",
        "oat-sa/generis": "dev-develop",
        "oat-sa/phing-task-tao": "~0.1",
        "oat-sa/tao-core": "dev-experiemnt/NEX-89-trans-deps",
        "oat-sa/composer-npm-bridge": "dev-feature/move-to-php56"
    },
``` 
into a php5.6 env should help you to test it

