### PR TITLE
Composer 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "type": "composer-plugin",
     "require": {
         "php": ">=5.6",
-        "composer-plugin-api": "^1"
+        "composer-plugin-api": "^1.0 || ^2.0"
     },
     "require-dev": {
         "composer/composer": "dev-master",

--- a/src/NpmBridgePlugin.php
+++ b/src/NpmBridgePlugin.php
@@ -79,4 +79,12 @@ class NpmBridgePlugin implements PluginInterface, EventSubscriberInterface
     }
 
     private $bridgeFactory;
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }

--- a/test/suite/NpmBridgeTest.php
+++ b/test/suite/NpmBridgeTest.php
@@ -6,6 +6,7 @@ use Composer\Composer;
 use Composer\Package\Link;
 use Composer\Package\Package;
 use Composer\Package\RootPackage;
+use Composer\Semver\Constraint\Constraint;
 use Eloquent\Composer\NpmBridge\Exception\NpmNotFoundException;
 use Eloquent\Phony\Phpunit\Phony;
 use PHPUnit\Framework\TestCase;
@@ -27,9 +28,9 @@ class NpmBridgeTest extends TestCase
         $this->packageA = new Package('vendorA/packageA', '1.0.0.0', '1.0.0');
         $this->packageB = new Package('vendorB/packageB', '1.0.0.0', '1.0.0');
 
-        $this->linkRoot1 = new Link('vendor/package', 'vendorX/packageX');
-        $this->linkRoot2 = new Link('vendor/package', 'vendorY/packageY');
-        $this->linkRoot3 = new Link('vendor/package', 'oat-sa/composer-npm-bridge');
+        $this->linkRoot1 = new Link('vendor/package', 'vendorX/packageX', new Constraint('>=', '1.0.0'));
+        $this->linkRoot2 = new Link('vendor/package', 'vendorY/packageY', new Constraint('>=', '1.0.0'));
+        $this->linkRoot3 = new Link('vendor/package', 'oat-sa/composer-npm-bridge', new Constraint('>=', '1.0.0'));
 
         $this->installationManager = Phony::mock('Composer\Installer\InstallationManager');
         $this->installationManager->getInstallPath->with($this->packageA)->returns('/path/to/install/a');

--- a/test/suite/NpmVendorFinderTest.php
+++ b/test/suite/NpmVendorFinderTest.php
@@ -7,6 +7,7 @@ use Composer\IO\NullIO;
 use Composer\Package\Link;
 use Composer\Package\Package;
 use Composer\Repository\ArrayRepository;
+use Composer\Semver\Constraint\Constraint;
 use Eloquent\Phony\Phpunit\Phony;
 use PHPUnit\Framework\TestCase;
 
@@ -27,14 +28,14 @@ class NpmVendorFinderTest extends TestCase
         $this->packageC = new Package('vendorC/packageC', '1.0.0.0', '1.0.0');
         $this->packageD = new Package('vendorD/packageD', '1.0.0.0', '1.0.0');
 
-        $this->linkA1 = new Link('vendorA/packageA', 'vendorX/packageX');
-        $this->linkA2 = new Link('vendorA/packageA', 'vendorY/packageY');
-        $this->linkB1 = new Link('vendorB/packageB', 'vendorZ/packageZ');
-        $this->linkB2 = new Link('vendorB/packageB', 'oat-sa/composer-npm-bridge');
-        $this->linkC1 = new Link('vendorC/packageC', 'vendorZ/packageZ');
-        $this->linkC2 = new Link('vendorC/packageC', 'oat-sa/composer-npm-bridge');
-        $this->linkD1 = new Link('vendorD/packageD', 'oat-sa/composer-npm-bridge');
-        $this->linkD2 = new Link('vendorD/packageD', 'vendorZ/packageZ');
+        $this->linkA1 = new Link('vendorA/packageA', 'vendorX/packageX', new Constraint('>=', '1.0.0'));
+        $this->linkA2 = new Link('vendorA/packageA', 'vendorY/packageY', new Constraint('>=', '1.0.0'));
+        $this->linkB1 = new Link('vendorB/packageB', 'vendorZ/packageZ', new Constraint('>=', '1.0.0'));
+        $this->linkB2 = new Link('vendorB/packageB', 'oat-sa/composer-npm-bridge', new Constraint('>=', '1.0.0'));
+        $this->linkC1 = new Link('vendorC/packageC', 'vendorZ/packageZ', new Constraint('>=', '1.0.0'));
+        $this->linkC2 = new Link('vendorC/packageC', 'oat-sa/composer-npm-bridge', new Constraint('>=', '1.0.0'));
+        $this->linkD1 = new Link('vendorD/packageD', 'oat-sa/composer-npm-bridge', new Constraint('>=', '1.0.0'));
+        $this->linkD2 = new Link('vendorD/packageD', 'vendorZ/packageZ', new Constraint('>=', '1.0.0'));
 
         $this->composer->setRepositoryManager($this->repositoryManager->get());
         $this->repositoryManager->getLocalRepository->returns($this->localRepository);


### PR DESCRIPTION
Composer 2 support for `npm-bridge`. With these changes applied the bridge should work with both major Composer versions.

In this PR I'm implementing the new methods introduced by `Composer\Plugin\PluginInterface`. Since no actual task has to be performed upon these method calls, method bodies are empty. 

Some unit tests got updated too as the 3rd, optional parameter of `Composer\Package\Link` became mandatory in Composer 2.

⚠️  More advanced tests are necessary, any help is appreciated.