### PR TITLE
Add additional check of that extension is real TAO extension

### DIFF
--- a/src/NpmBridge.php
+++ b/src/NpmBridge.php
@@ -97,6 +97,14 @@ class NpmBridge
             }
         }
 
+        // Check custom TAO extension config and if it has NPM Bridge configuration, run assets bulding
+        if (
+            $package->getType() === 'tao-extension'
+            && array_key_exists('npm-bridge', $package->getExtra())
+        ) {
+            return true;
+        }
+
         return false;
     }
 

--- a/src/NpmBridge.php
+++ b/src/NpmBridge.php
@@ -97,15 +97,9 @@ class NpmBridge
             }
         }
 
-        // Check custom TAO extension config and if it has NPM Bridge configuration, run assets bulding
-        if (
-            $package->getType() === 'tao-extension'
+        return $package->getType() === 'tao-extension'
             && array_key_exists('npm-bridge', $package->getExtra())
-        ) {
-            return true;
         }
-
-        return false;
     }
 
     private function installForVendors($composer)


### PR DESCRIPTION
It will allow us to avoid require `composer-npm-bridge` in each extension, which now is causing issues with version constraints during updating. After the fix, the proper version will be included only in `tao-core`, but each extension will contain npm-bridge configuration as it was before.