### PR TITLE
fix: run npm ci instead of install

### DIFF
--- a/src/NpmClient.php
+++ b/src/NpmClient.php
@@ -65,9 +65,9 @@ class NpmClient
     public function install($path = null, $isDevMode = true, $timeout = null, $npmArguments = [])
     {
         if ($isDevMode) {
-            $arguments = ['install'];
+            $arguments = ['ci'];
         } else {
-            $arguments = ['install', '--production'];
+            $arguments = ['ci', '--production'];
         }
 
         $arguments = array_merge($arguments, $npmArguments);

--- a/test/suite/NpmClientTest.php
+++ b/test/suite/NpmClientTest.php
@@ -36,7 +36,7 @@ class NpmClientTest extends TestCase
             $this->executableFinder->find->calledWith('npm'),
             $this->processExecutorClass->getTimeout->called(),
             $this->processExecutorClass->setTimeout->calledWith(NpmClient::DEFAULT_TIMEOUT),
-            $this->processExecutor->execute->calledWith("'/path/to/npm' 'install'"),
+            $this->processExecutor->execute->calledWith("'/path/to/npm' 'ci'"),
             $this->processExecutorClass->setTimeout->calledWith(
                 $this->processExecutorClass->getTimeout->firstCall()->returnValue()
             )
@@ -50,7 +50,7 @@ class NpmClientTest extends TestCase
 
         Phony::inOrder(
             $this->chdir->calledWith('/path/to/project'),
-            $this->processExecutor->execute->calledWith("'/path/to/npm' 'install'"),
+            $this->processExecutor->execute->calledWith("'/path/to/npm' 'ci'"),
             $this->chdir->calledWith('/path/to/cwd')
         );
     }
@@ -59,7 +59,7 @@ class NpmClientTest extends TestCase
     {
         $this->client->install(null, false);
 
-        $this->processExecutor->execute->calledWith("'/path/to/npm' 'install' '--production'");
+        $this->processExecutor->execute->calledWith("'/path/to/npm' 'ci' '--production'");
     }
 
     public function testInstallFailureNpmNotFound()


### PR DESCRIPTION
Problem: 
 - `npm install` updates the dependencies based on the pattern and update the lock file
 
Solution: 
 - `npm ci` install from the lock file

We should always install dependencies with `npm ci`

How to test:
 - run unit test `./vendor/bin/phpunit`
 - try by updating it in tao-core's composer  : `"oat-sa/composer-npm-bridge": "dev-fix/run-ci-instead-of-install", `