### PR TITLE
chore: print npm-command failure output message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Composer NPM bridge changelog
 
+##  0.4.3
+
+- Update NPM command failure message to include the complete output
+
 ##  0.4.2
 
 - Fix typo after merging GitHub suggestion from code review

--- a/src/Exception/NpmCommandFailedException.php
+++ b/src/Exception/NpmCommandFailedException.php
@@ -15,12 +15,12 @@ final class NpmCommandFailedException extends Exception
      * @param string         $command The executed command.
      * @param Exception|null $cause   The cause, if available.
      */
-    public function __construct($command, Exception $cause = null)
+    public function __construct($command, $output, Exception $cause = null)
     {
         $this->command = $command;
 
         parent::__construct(
-            sprintf('Execution of %s failed.', var_export($command, true)),
+            "Execution of `$command` failed with the following output:\n$output",
             0,
             $cause
         );

--- a/src/NpmClient.php
+++ b/src/NpmClient.php
@@ -109,7 +109,7 @@ class NpmClient
         call_user_func($this->setTimeout, $timeout);
 
         $this->processExecutor->execute('pwd');
-        $exitCode = $this->processExecutor->execute($command);
+        $exitCode = $this->processExecutor->execute($command, $output);
 
         call_user_func($this->setTimeout, $oldTimeout);
 
@@ -118,7 +118,7 @@ class NpmClient
         }
 
         if (0 !== $exitCode) {
-            throw new NpmCommandFailedException($command);
+            throw new NpmCommandFailedException($command, $output);
         }
     }
 

--- a/test/suite/Exception/NpmCommandFailedExceptionTest.php
+++ b/test/suite/Exception/NpmCommandFailedExceptionTest.php
@@ -10,10 +10,10 @@ class NpmCommandFailedExceptionTest extends TestCase
     public function testException()
     {
         $cause = new Exception();
-        $exception = new NpmCommandFailedException('command', $cause);
+        $exception = new NpmCommandFailedException('command', 'output', $cause);
 
         $this->assertSame('command', $exception->command());
-        $this->assertSame("Execution of 'command' failed.", $exception->getMessage());
+        $this->assertSame("Execution of `command` failed with the following output:\noutput", $exception->getMessage());
         $this->assertSame(0, $exception->getCode());
         $this->assertSame($cause, $exception->getPrevious());
     }


### PR DESCRIPTION
This PR should help to debug the NPM package installation errors in CI.

@tikhanovichA, after merging this (if all is well from your PoV), could you please do the following?
1. Release and tag this version
2. Update the dependency on it within tao-construct by running `composer update oat-sa/composer-npm-bridge` there
3. Push the updated dependency to tao-construct to see the actual error in CI logs