### PR TITLE
fix: capture error output from NPM command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ##  0.4.6
 
-- Fix capturing error output from NPM command
+- Fix NPM process logging by injecting the Composer IO object to the process executor
 
 ##  0.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Composer NPM bridge changelog
 
-##  0.4.4
+##  0.4.6
 
 - Fix capturing error output from NPM command
 
-##  0.4.3
+##  0.4.5
 
 - Update NPM command failure message to include the complete output
+
+##  0.4.4
+
+- fix DEFAULT_TIMEOUT to 3000
+
+##  0.4.3
+
+- Fix run `npm ci` instead of `npm install`
 
 ##  0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Composer NPM bridge changelog
 
+##  0.4.4
+
+- Fix capturing error output from NPM command
+
 ##  0.4.3
 
 - Update NPM command failure message to include the complete output

--- a/src/Exception/NpmCommandFailedException.php
+++ b/src/Exception/NpmCommandFailedException.php
@@ -15,12 +15,12 @@ final class NpmCommandFailedException extends Exception
      * @param string         $command The executed command.
      * @param Exception|null $cause   The cause, if available.
      */
-    public function __construct($command, $output, Exception $cause = null)
+    public function __construct($command, Exception $cause = null)
     {
         $this->command = $command;
 
         parent::__construct(
-            "Execution of `$command` failed with the following output:\n$output",
+            sprintf('Execution of %s failed.', var_export($command, true)),
             0,
             $cause
         );

--- a/src/NpmBridgeFactory.php
+++ b/src/NpmBridgeFactory.php
@@ -45,7 +45,7 @@ class NpmBridgeFactory
      */
     public function createBridge(IOInterface $io)
     {
-        return new NpmBridge($io, $this->vendorFinder, $this->client);
+        return new NpmBridge($io, $this->vendorFinder, $this->client->setIo($io));
     }
 
     private $vendorFinder;

--- a/src/NpmClient.php
+++ b/src/NpmClient.php
@@ -2,6 +2,7 @@
 
 namespace Eloquent\Composer\NpmBridge;
 
+use Composer\IO\IOInterface;
 use Composer\Util\ProcessExecutor;
 use Eloquent\Composer\NpmBridge\Exception\NpmCommandFailedException;
 use Eloquent\Composer\NpmBridge\Exception\NpmNotFoundException;
@@ -22,6 +23,12 @@ class NpmClient
     public static function create()
     {
         return new self(new ProcessExecutor(), new ExecutableFinder());
+    }
+
+    public function setIo(IOInterface $io)
+    {
+        $this->processExecutor = new ProcessExecutor($io);
+        return $this;
     }
 
     /**
@@ -118,7 +125,7 @@ class NpmClient
         }
 
         if (0 !== $exitCode) {
-            throw new NpmCommandFailedException($command, $this->processExecutor->getErrorOutput());
+            throw new NpmCommandFailedException($command);
         }
     }
 

--- a/src/NpmClient.php
+++ b/src/NpmClient.php
@@ -109,7 +109,7 @@ class NpmClient
         call_user_func($this->setTimeout, $timeout);
 
         $this->processExecutor->execute('pwd');
-        $exitCode = $this->processExecutor->execute($command, $output);
+        $exitCode = $this->processExecutor->execute($command);
 
         call_user_func($this->setTimeout, $oldTimeout);
 
@@ -118,7 +118,7 @@ class NpmClient
         }
 
         if (0 !== $exitCode) {
-            throw new NpmCommandFailedException($command, $output);
+            throw new NpmCommandFailedException($command, $this->processExecutor->getErrorOutput());
         }
     }
 

--- a/test/suite/Exception/NpmCommandFailedExceptionTest.php
+++ b/test/suite/Exception/NpmCommandFailedExceptionTest.php
@@ -10,10 +10,10 @@ class NpmCommandFailedExceptionTest extends TestCase
     public function testException()
     {
         $cause = new Exception();
-        $exception = new NpmCommandFailedException('command', 'output', $cause);
+        $exception = new NpmCommandFailedException('command', $cause);
 
         $this->assertSame('command', $exception->command());
-        $this->assertSame("Execution of `command` failed with the following output:\noutput", $exception->getMessage());
+        $this->assertSame("Execution of 'command' failed.", $exception->getMessage());
         $this->assertSame(0, $exception->getCode());
         $this->assertSame($cause, $exception->getPrevious());
     }


### PR DESCRIPTION
This is a follow up to #21 